### PR TITLE
#require() improvements

### DIFF
--- a/nodify.js
+++ b/nodify.js
@@ -42,7 +42,7 @@ var global = window, process;
     var requireDir = rootPath;
     
     require = function(path) {
-      var i, dir, paths = [], fileGuesses = [], file, code, fn;
+      var i, dir, file, code, fn;
       var fileGuesses = []
       var paths = global.module['paths'].slice(0);
       var oldRequireDir = requireDir;


### PR DESCRIPTION
We had to fix `#require()` to improve modules discovery. Also, coffee script is now hookable.

Patches by @adiroiban
